### PR TITLE
Smc c code

### DIFF
--- a/src/asm/smc3/smc3_test.c
+++ b/src/asm/smc3/smc3_test.c
@@ -93,7 +93,7 @@ post:
     ptr_tpl_end = ptr_tpl_reg11 + SIZE_TPL_INIT_INST + SIZE_TPL_BODY_INST;
     for (int i=0; i<SIZE_TPL_END_INST; i++) {
         ptr_gen_reg9[i] = ptr_tpl_end[i];
-        if(i == 1) ptr_gen_reg9[i] -= 45;
+        if(i == TPL_END_JUMP_ADDR_OFFSET) ptr_gen_reg9[i] -= 45;
     }
 
     //jal gen

--- a/src/asm/smc3/smc3_test.c
+++ b/src/asm/smc3/smc3_test.c
@@ -1,0 +1,137 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/mman.h>
+
+#define GEN_OFFSET 483 // 983 - 77a
+#define TPL_OFFSET 462 // 939 - 77a
+
+#define SIZE_TPL_INIT_INST 7  
+#define SIZE_TPL_BODY_INST 12
+#define SIZE_TPL_END_INST 2
+
+#define TPL_END_JUMP_ADDR_OFFSET 1 // eb cf (jmp  ...)
+
+#define TPL_VEC1_INDEX 2
+#define TPL_VEC2_INDEX 5
+
+int change_page_permissions_of_address(void *addr);
+void get_permission(void* foo_addr);
+int gen();
+
+char* err_string = "Error while changing page permissions of foo()\n";
+
+int main(void){
+    int innerprod_reg2;
+    int vec1[] = {22, 0, 25};
+    int vec2[] = {7, 429, 6};
+
+    int result = 0;
+
+    unsigned char*  ptr_gen_reg9;
+    unsigned char*  ptr_tpl_reg11;
+
+    unsigned char*  ptr_tpl_end;
+    unsigned char*  ptr_tpl_body;
+
+    int             vec_length_reg4;       //$4
+    int             vec_index_reg8;        //$8, counter
+    int             offset_gen;
+    int             dummy;
+
+    // initialize
+    get_permission(main);
+
+start:
+    //li $4, 3
+    vec_length_reg4 = 3;
+
+    //li $8, 0
+    vec_index_reg8 = 0;
+
+    //la $9, gen
+    ptr_gen_reg9 = (unsigned char*)main + GEN_OFFSET;
+
+    //la $11, tpl
+    ptr_tpl_reg11 = (unsigned char*)main + TPL_OFFSET;
+
+    //lw $12, 0($11)
+    //sw $12, 0($9)
+    for(int i = 0; i < SIZE_TPL_INIT_INST; i++) ptr_gen_reg9[i] = ptr_tpl_reg11[i];
+
+
+    //addi $9, $9, 4
+    ptr_gen_reg9 = ptr_gen_reg9 + SIZE_TPL_INIT_INST;
+
+loop:
+    //beq $8, $4, post
+    if(vec_index_reg8 == vec_length_reg4) goto post;
+
+    ptr_tpl_body = ptr_tpl_reg11 + SIZE_TPL_INIT_INST;
+
+
+    for(int i = 0; i < SIZE_TPL_BODY_INST; i++) ptr_gen_reg9[i] = ptr_tpl_body[i];
+
+    ptr_gen_reg9[TPL_VEC1_INDEX] += (unsigned char)(vec_index_reg8 * 4);
+    ptr_gen_reg9[TPL_VEC2_INDEX] += (unsigned char)(vec_index_reg8 * 4);
+
+
+    ptr_gen_reg9 += SIZE_TPL_BODY_INST;
+
+
+next:
+    vec_index_reg8++;
+
+    goto loop;
+
+post:
+    ptr_tpl_end = 
+      ptr_tpl_reg11 + SIZE_TPL_INIT_INST + SIZE_TPL_BODY_INST;
+
+    for (int i=0; i<SIZE_TPL_END_INST; i++) {
+        ptr_gen_reg9[i] = ptr_tpl_end[i];
+        if(i == 1) ptr_gen_reg9[i] -= 45;
+    }
+
+    
+    goto gen;
+
+after_call_gen:
+    result = innerprod_reg2;
+    // j main
+    printf("%d \n", result);    
+
+tpl:
+    innerprod_reg2 = 0;
+    innerprod_reg2 = innerprod_reg2 + vec1[0] * vec2[0];
+    goto after_call_gen;
+
+gen:
+    // get_permission 코드 위에 오버라이팅!!
+    goto after_call_gen;
+}
+
+
+///////////////////////////////
+// Permission-related functions
+///////////////////////////////
+void get_permission(void* foo_addr) {
+    if(change_page_permissions_of_address(foo_addr) == -1) {
+        write(STDERR_FILENO, err_string, strlen(err_string) + 1);
+        exit(1);
+    }    
+}
+int change_page_permissions_of_address(void *addr){
+    
+    int page_size = 4096;
+
+    addr -= (unsigned long)addr % page_size;
+
+    if(mprotect(addr, page_size, PROT_READ | PROT_WRITE | PROT_EXEC) == -1){
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/asm/smc3/smc3_test.c
+++ b/src/asm/smc3/smc3_test.c
@@ -38,8 +38,6 @@ int main(void){
 
     int             vec_length_reg4;       //$4
     int             vec_index_reg8;        //$8, counter
-    int             offset_gen;
-    int             dummy;
 
     // initialize
     get_permission(main);

--- a/src/asm/smc3/smc3_test.c
+++ b/src/asm/smc3/smc3_test.c
@@ -5,14 +5,14 @@
 #include <errno.h>
 #include <sys/mman.h>
 
-#define GEN_OFFSET 483 // 983 - 77a
-#define TPL_OFFSET 462 // 939 - 77a
+#define GEN_OFFSET 483
+#define TPL_OFFSET 462
 
 #define SIZE_TPL_INIT_INST 7  
 #define SIZE_TPL_BODY_INST 12
 #define SIZE_TPL_END_INST 2
 
-#define TPL_END_JUMP_ADDR_OFFSET 1 // eb cf (jmp  ...)
+#define TPL_END_JUMP_ADDR_OFFSET 1
 
 #define TPL_VEC1_INDEX 2
 #define TPL_VEC2_INDEX 5
@@ -68,39 +68,42 @@ start:
 loop:
     //beq $8, $4, post
     if(vec_index_reg8 == vec_length_reg4) goto post;
-
+    
+    //lw $12, (0, 4, 8)$11
+    //sw $12, (0, 4, 8)$11
     ptr_tpl_body = ptr_tpl_reg11 + SIZE_TPL_INIT_INST;
-
-
     for(int i = 0; i < SIZE_TPL_BODY_INST; i++) ptr_gen_reg9[i] = ptr_tpl_body[i];
 
+    //add $12, $12, $13
+    //add $12, $12, $10
     ptr_gen_reg9[TPL_VEC1_INDEX] += (unsigned char)(vec_index_reg8 * 4);
     ptr_gen_reg9[TPL_VEC2_INDEX] += (unsigned char)(vec_index_reg8 * 4);
 
 
+    //addi $9, $9, 16
     ptr_gen_reg9 += SIZE_TPL_BODY_INST;
 
-
 next:
+    // addi $8, $8, 1
     vec_index_reg8++;
-
+    // j loop
     goto loop;
 
 post:
-    ptr_tpl_end = 
-      ptr_tpl_reg11 + SIZE_TPL_INIT_INST + SIZE_TPL_BODY_INST;
-
+    //lw $12, 20($11)
+    //sw $12, 0($9)
+    ptr_tpl_end = ptr_tpl_reg11 + SIZE_TPL_INIT_INST + SIZE_TPL_BODY_INST;
     for (int i=0; i<SIZE_TPL_END_INST; i++) {
         ptr_gen_reg9[i] = ptr_tpl_end[i];
         if(i == 1) ptr_gen_reg9[i] -= 45;
     }
 
-    
+    //jal gen
     goto gen;
 
 after_call_gen:
     result = innerprod_reg2;
-    // j main
+
     printf("%d \n", result);    
 
 tpl:


### PR DESCRIPTION
어제 회의가 끝난 직후 교수님께서 작성하신 SMC3 Local Var.c 기준으로 복사하여 smc3_test.c파일을 작성해보았습니다.
해당 코드는 무한루프로 동작하고, 정상적으로 실행된다는것을 확인하는 방법은 아래와 같습니다.
gcc smc3_test.c
./a.out > a.log
Ctrl+C하여 프로그램 종료
이때 a.log의 맨 윗줄을 보시면 정확하게 내적값이 출력되는것을 볼 수 있습니다.

어제 저희가 마주쳤던 최적화 문제와 jmp 상대주소 문제를 해결하기 위해 다음과같이 코딩했습니다.

1. 최적화 문제
```
for (int i=0; i<SIZE_TPL_END_INST; i++) { 
    ptr_gen_reg9[i] = ptr_tpl_end[i];  
}
    ptr_gen_reg9[TPL_END_JUMP_ADDR_OFFSET] -= nonzero * 20; 
```
이해는 할 수 없지만 해당부분에서 ptr_gen_reg9[TPL_END_JUMP_ADDR_OFFSET] -= nonzero * 20; 이부분으로 인해 최적화가 발생하였습니다. 아마도 for문을 사용하고 바로 goto문을 사용하면 최적화가 일어나지 않는것 같습니다.

그렇기 때문에 해당 부분을 for문안에서 if문을 이용하여 감소를 시켰습니다.


2. jmp 상대주소
해당부분은 교수님께서 말씀하신것처럼 논문에는 vec1이 0인 원소에 대해서는 코드블럭을 생성하지 않지만 현재 PR된 코드에서는 그 부분을 삭제해 vec1이 0인 원소에 대해서도 코드블럭이 생성되도록 하였습니다.
그래서 상대주소를 하드코딩해서 체크하였고 해당부분을 해결했습니다.

그래서 위의 2가지문제를 해결하기 위해 다음과 같이 코드를 작성했습니다.
```
 for (int i=0; i<SIZE_TPL_END_INST; i++) {
        ptr_gen_reg9[i] = ptr_tpl_end[i];
        if(i == 1) ptr_gen_reg9[i] -= 45;
    }
```

리뷰 부탁드리겠습니다!
